### PR TITLE
allow unpinning other users messages

### DIFF
--- a/src/client/components/note-detailed.vue
+++ b/src/client/components/note-detailed.vue
@@ -643,7 +643,7 @@ export default defineComponent({
 					text: this.$ts.watch,
 					action: () => this.toggleWatch(true)
 				}) : undefined,
-				this.appearNote.userId == this.$i.id ? (this.$i.pinnedNoteIds || []).includes(this.appearNote.id) ? {
+				true ? (this.$i.pinnedNoteIds || []).includes(this.appearNote.id) ? {
 					icon: 'fas fa-thumbtack',
 					text: this.$ts.unpin,
 					action: () => this.togglePin(false)

--- a/src/client/ui/chat/note.vue
+++ b/src/client/ui/chat/note.vue
@@ -625,7 +625,7 @@ export default defineComponent({
 					text: this.$ts.watch,
 					action: () => this.toggleWatch(true)
 				}) : undefined,
-				this.appearNote.userId == this.$i.id ? (this.$i.pinnedNoteIds || []).includes(this.appearNote.id) ? {
+				true ? (this.$i.pinnedNoteIds || []).includes(this.appearNote.id) ? {
 					icon: 'fas fa-thumbtack',
 					text: this.$ts.unpin,
 					action: () => this.togglePin(false)

--- a/src/services/i/pin.ts
+++ b/src/services/i/pin.ts
@@ -58,7 +58,6 @@ export async function removePinned(user: { id: User['id']; host: User['host']; }
 	// Fetch unpinee
 	const note = await Notes.findOne({
 		id: noteId,
-		userId: user.id
 	});
 
 	if (note == null) {


### PR DESCRIPTION
A previous commit allowed users to pin other users' messages to their
profile. However, this commit did not allow users to unpin those
messages. This commit fixes that.


<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
