### PR TITLE
Masto tweaks

### DIFF
--- a/src/client/components/post-form.vue
+++ b/src/client/components/post-form.vue
@@ -237,15 +237,17 @@ export default defineComponent({
 			this.text += ' ';
 		}
 
-		if (this.reply && this.reply.user.host != null) {
-			this.text = `@${this.reply.user.username}@${toASCII(this.reply.user.host)} `;
+		if (this.reply &&
+      (this.$store.state.localMentions ? this.reply.userId !== this.$i.id : this.reply.user.host != null)
+    ) {
+			this.text = this.reply.user.host ? `@${this.reply.user.username}@${toASCII(this.reply.user.host)} ` : `@${this.reply.user.username} `;
 		}
 
 		if (this.reply && this.reply.text != null) {
 			const ast = mfm.parse(this.reply.text);
 
 			for (const x of extractMentions(ast)) {
-				const mention = x.host ? `@${x.username}@${toASCII(x.host)}` : `@${x.username}`;
+				const mention = x.host ? x.host != host ? `@${x.username}@${toASCII(x.host)}` : `@${x.username}` : `@${x.username}`;
 
 				// 自分は除外
 				if (this.$i.username == x.username && x.host == null) continue;

--- a/src/client/store.ts
+++ b/src/client/store.ts
@@ -17,7 +17,7 @@ export const defaultStore = markRaw(new Storage('base', {
 	},
 	keepCw: {
 		where: 'account',
-		default: false
+		default: true
 	},
 	showFullAcct: {
 		where: 'account',

--- a/src/client/store.ts
+++ b/src/client/store.ts
@@ -19,6 +19,10 @@ export const defaultStore = markRaw(new Storage('base', {
 		where: 'account',
 		default: true
 	},
+	localMentions: {
+		where: 'account',
+		default: true
+	},
 	showFullAcct: {
 		where: 'account',
 		default: false


### PR DESCRIPTION
This PR makes two changes that make misskey usability a bit better for people migrating from Mastodon, since that's the majority of our userbase.

The first is that the `keepCw` registry flag is changed to `true` by default. This tells the client to include a CW on a reply if the original note already has one. While this flag exists in upstream, there is not a way to toggle it without editing the registry yourself.

The second adds a new registry flag, called `localMentions`. When this registry flag is `true`, Misskey will include mentions in replies when replying to on-instance users other than yourself. This duplicates existing behavior in Mastodon. When the registry flag is `false`, Misskey will retain the old behavior, which only includes mentions in replies when replying to an off-instance user. This flag is set to `true` by default.

Adding a new registry flag should not impact our compatibility with upstream unless they add a flag with the exact same name.

Similar, though not exact patches are currently running on egirls.