### PR TITLE
make sure pin always shows up on actual component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pluskey",
 	"author": "foggy <foggy@foggy.llc>",
-	"version": "12.81.2+plus",
+	"version": "12.81.2+plus1",
 	"codename": "indigo",
 	"repository": {
 		"type": "git",

--- a/src/client/components/note.vue
+++ b/src/client/components/note.vue
@@ -802,7 +802,7 @@ export default defineComponent({
 									  }
 						  )
 						: undefined,
-					this.appearNote.userId == this.$i.id
+					true
 						? (this.$i.pinnedNoteIds || []).includes(this.appearNote.id)
 							? {
 									icon: "fas fa-thumbtack",


### PR DESCRIPTION
This one was my bad, I half-reverted some of the pin/unpin other user stuff so this understandably got missed since it was broken already.